### PR TITLE
Add confirm delete setting

### DIFF
--- a/Sources/DirectoryBrowser/DirectoryBrowser.swift
+++ b/Sources/DirectoryBrowser/DirectoryBrowser.swift
@@ -10,7 +10,7 @@ public struct DirectoryBrowser: View {
 
     public init(
         urls: [URL] = [.documentsDirectory, .libraryDirectory, .temporaryDirectory],
-        confirmDelete: Bool = false
+        confirmDelete: Bool = true
     ) {
         self.urls = urls
         _confirmDelete = State(initialValue: confirmDelete)

--- a/Sources/DirectoryBrowser/DirectoryBrowser.swift
+++ b/Sources/DirectoryBrowser/DirectoryBrowser.swift
@@ -5,11 +5,15 @@ import FilePreviews
 public struct DirectoryBrowser: View {
     @StateObject var thumbnailer = Thumbnailer()
     private var urls: [URL]
+    @State private var confirmDelete: Bool
+    @State private var showSettings = false
 
     public init(
-        urls: [URL] = [.documentsDirectory, .libraryDirectory, .temporaryDirectory]
+        urls: [URL] = [.documentsDirectory, .libraryDirectory, .temporaryDirectory],
+        confirmDelete: Bool = false
     ) {
         self.urls = urls
+        _confirmDelete = State(initialValue: confirmDelete)
     }
 
     public var body: some View {
@@ -19,8 +23,20 @@ public struct DirectoryBrowser: View {
                     FolderView(documentsStore: DocumentsStore(root: url), title: url.lastPathComponent)
                 }
             }
+            .navigationTitle("Directories")
+#if os(iOS)
+            .navigationBarItems(trailing:
+                Button(action: { showSettings = true }) {
+                    Image(systemName: "gearshape")
+                }
+            )
+#endif
+        }
+        .sheet(isPresented: $showSettings) {
+            SettingsView(confirmDelete: $confirmDelete)
         }
         .environmentObject(thumbnailer)
+        .environment(\.confirmDelete, confirmDelete)
     }
 }
 

--- a/Sources/DirectoryBrowser/Environment/ConfirmDeleteKey.swift
+++ b/Sources/DirectoryBrowser/Environment/ConfirmDeleteKey.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct ConfirmDeleteKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+public extension EnvironmentValues {
+    var confirmDelete: Bool {
+        get { self[ConfirmDeleteKey.self] }
+        set { self[ConfirmDeleteKey.self] = newValue }
+    }
+}

--- a/Sources/DirectoryBrowser/Screens/Folder/DocumentRow.swift
+++ b/Sources/DirectoryBrowser/Screens/Folder/DocumentRow.swift
@@ -10,6 +10,8 @@ struct DocumentRow: View {
     @State private var isEditing = false
     @FocusState private var nameEditIsFocused: Bool
     @State private var documentNameErrorMessage: String?
+    @Environment(\.confirmDelete) private var confirmDelete
+    @State private var showDeleteConfirm = false
 
     var body: some View {
         HStack (alignment: .center, spacing: 16) {
@@ -45,6 +47,10 @@ struct DocumentRow: View {
         }
         .onAppear {
             isEditing = shouldEdit
+        }
+        .alert("Delete this document?", isPresented: $showDeleteConfirm) {
+            Button("Delete", role: .destructive) { performDelete() }
+            Button("Cancel", role: .cancel) { }
         }
     }
 
@@ -109,6 +115,14 @@ struct DocumentRow: View {
     }
 
     private func deleteDocument() {
+        if confirmDelete {
+            showDeleteConfirm = true
+        } else {
+            performDelete()
+        }
+    }
+
+    private func performDelete() {
         withAnimation {
             documentsStore.delete(document)
         }
@@ -129,6 +143,7 @@ struct DocumentRow_Previews: PreviewProvider {
             .previewLayout(.sizeThatFits)
             .preferredColorScheme(.dark)
             .environmentObject(Thumbnailer())
+            .environment(\.confirmDelete, true)
         }
     }
 }

--- a/Sources/DirectoryBrowser/Screens/Folder/FolderView.swift
+++ b/Sources/DirectoryBrowser/Screens/Folder/FolderView.swift
@@ -10,6 +10,10 @@ public struct FolderView: View {
     @ObservedObject var documentsStore: DocumentsStore
     var title: String
 
+    @Environment(\.confirmDelete) private var confirmDelete
+    @State private var showDeleteConfirm = false
+    @State private var pendingDeleteOffsets: IndexSet?
+
     @ViewBuilder
     var listSectionHeader: some View {
         Text("All")
@@ -121,6 +125,17 @@ public struct FolderView: View {
         .task {
             documentsStore.loadDocuments()
         }
+        .alert("Delete selected documents?", isPresented: $showDeleteConfirm) {
+            Button("Delete", role: .destructive) {
+                if let offsets = pendingDeleteOffsets {
+                    performDelete(offsets: offsets)
+                    pendingDeleteOffsets = nil
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDeleteOffsets = nil
+            }
+        }
     }
 
     @ViewBuilder
@@ -157,6 +172,15 @@ public struct FolderView: View {
     }
 
     private func deleteItems(offsets: IndexSet) {
+        if confirmDelete {
+            pendingDeleteOffsets = offsets
+            showDeleteConfirm = true
+        } else {
+            performDelete(offsets: offsets)
+        }
+    }
+
+    private func performDelete(offsets: IndexSet) {
         offsets
             .map { documentsStore.documents[$0] }
             .forEach { deleteDocument($0) }
@@ -176,6 +200,7 @@ struct FolderView_Previews: PreviewProvider {
         NavigationView {
             FolderView(documentsStore: DocumentsStore_Preview(root: URL.temporaryDirectory, relativePath: "/", sorting: .date(ascending: true)), title: "Docs")
                 .environmentObject(Thumbnailer())
+                .environment(\.confirmDelete, true)
         }
     }
 }

--- a/Sources/DirectoryBrowser/Screens/Folder/FolderView.swift
+++ b/Sources/DirectoryBrowser/Screens/Folder/FolderView.swift
@@ -39,7 +39,6 @@ public struct FolderView: View {
                 }
             } label: {
                 Image(systemName: "arrow.up.arrow.down")
-                    .font(.title2)
                     .foregroundColor(.blue)
             }
             Menu {
@@ -57,7 +56,6 @@ public struct FolderView: View {
                 }
             } label: {
                 Image(systemName: "doc.fill.badge.plus")
-                    .font(.title2)
                     .help(Text("Add documents"))
             }
         }

--- a/Sources/DirectoryBrowser/Screens/Settings/SettingsView.swift
+++ b/Sources/DirectoryBrowser/Screens/Settings/SettingsView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Binding var confirmDelete: Bool
+    @Environment(\.presentationMode) private var presentation
+
+    init(confirmDelete: Binding<Bool>) {
+        self._confirmDelete = confirmDelete
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Toggle("Confirm Delete", isOn: $confirmDelete)
+            }
+            .navigationTitle("Settings")
+#if os(iOS)
+            .navigationBarItems(trailing: Button("Done") { presentation.wrappedValue.dismiss() })
+#endif
+        }
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView(confirmDelete: .constant(true))
+    }
+}

--- a/Tests/DirectoryBrowserTests/UtilsTests/ConfirmDeleteEnvironmentTests.swift
+++ b/Tests/DirectoryBrowserTests/UtilsTests/ConfirmDeleteEnvironmentTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import SwiftUI
+@testable import DirectoryBrowser
+
+final class ConfirmDeleteEnvironmentTests: XCTestCase {
+    func testDefaultValue() {
+        let values = EnvironmentValues()
+        XCTAssertFalse(values.confirmDelete)
+    }
+
+    func testSetValue() {
+        var values = EnvironmentValues()
+        values.confirmDelete = true
+        XCTAssertTrue(values.confirmDelete)
+    }
+}


### PR DESCRIPTION
## Summary
- add a confirm delete environment key
- show confirm dialog before deleting a document when enabled
- inject confirm delete setting from DirectoryBrowser
- add settings screen with a toggle to change the option
- test environment key defaults

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6858045a1b2883239662266b5783fc79