### PR TITLE
Implement basic search across directories

### DIFF
--- a/Sources/DirectoryBrowser/Screens/Search/SearchResultRow.swift
+++ b/Sources/DirectoryBrowser/Screens/Search/SearchResultRow.swift
@@ -1,0 +1,18 @@
+import DirectoryManager
+import SwiftUI
+
+struct SearchResultRow: View {
+    var result: DocumentSearchResult
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: result.document.isDirectory ? "folder" : "doc")
+            VStack(alignment: .leading) {
+                Text(result.document.name)
+                Text(humanReadablePath(for: result.document.url, root: result.root))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}

--- a/Sources/DirectoryBrowser/Screens/Search/SearchResultsView.swift
+++ b/Sources/DirectoryBrowser/Screens/Search/SearchResultsView.swift
@@ -1,0 +1,24 @@
+import DirectoryManager
+import SwiftUI
+
+struct SearchResultsView: View {
+    @ObservedObject var searcher: DocumentSearcher
+
+    var body: some View {
+        List(searcher.results) { result in
+            NavigationLink(destination: destination(for: result)) {
+                SearchResultRow(result: result)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func destination(for result: DocumentSearchResult) -> some View {
+        if result.document.isDirectory {
+            let rel = relativePath(for: result.document.url, root: result.root)
+            FolderView(documentsStore: DocumentsStore(root: result.root, relativePath: rel), title: result.document.name)
+        } else {
+            DocumentDetails(document: result.document)
+        }
+    }
+}

--- a/Sources/DirectoryBrowser/Utils/PathUtils.swift
+++ b/Sources/DirectoryBrowser/Utils/PathUtils.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public func humanReadablePath(for url: URL, root: URL) -> String {
+    var relative = url.path.replacingOccurrences(of: root.path, with: "")
+    if relative.hasPrefix("/") { relative.removeFirst() }
+    if relative.isEmpty { return root.lastPathComponent }
+    return root.lastPathComponent + "/" + relative
+}
+
+public func relativePath(for url: URL, root: URL) -> String {
+    var relative = url.path.replacingOccurrences(of: root.path, with: "")
+    if relative.hasPrefix("/") { relative.removeFirst() }
+    return "/" + relative
+}

--- a/Sources/DirectoryManager/DocumentSearcher.swift
+++ b/Sources/DirectoryManager/DocumentSearcher.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public struct DocumentSearchResult: Identifiable, Hashable {
+    public var id = UUID()
+    public var document: Document
+    public var root: URL
+
+    public init(document: Document, root: URL) {
+        self.document = document
+        self.root = root
+    }
+}
+
+@MainActor
+public class DocumentSearcher: ObservableObject {
+    @Published public private(set) var results: [DocumentSearchResult] = []
+
+    private let roots: [URL]
+    private let documentManager: DocumentManager
+    private let attrKeys: [URLResourceKey] = [.nameKey, .fileSizeKey, .contentModificationDateKey, .creationDateKey, .isDirectoryKey]
+
+    public init(roots: [URL], documentManager: DocumentManager = FileManager.default) {
+        self.roots = roots
+        self.documentManager = documentManager
+    }
+
+    public func search(query: String) {
+        results.removeAll()
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let lowercased = trimmed.lowercased()
+        for root in roots {
+            searchDirectory(root, root: root, query: lowercased)
+        }
+    }
+
+    public func clear() {
+        results.removeAll()
+    }
+
+    private func searchDirectory(_ directory: URL, root: URL, query: String) {
+        guard let contents = try? documentManager.contentsOfDirectory(at: directory) else { return }
+        for url in contents {
+            if let doc = document(from: url), doc.name.lowercased().contains(query) {
+                results.append(DocumentSearchResult(document: doc, root: root))
+            }
+            if docIsDirectory(url) {
+                searchDirectory(url, root: root, query: query)
+            }
+        }
+    }
+
+    private func docIsDirectory(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+    }
+
+    private func document(from url: URL) -> Document? {
+        do {
+            let attrVals = try url.resourceValues(forKeys: Set(attrKeys))
+            let fileName = attrVals.name ?? url.lastPathComponent
+            let created = attrVals.creationDate
+            let modified = attrVals.contentModificationDate
+            let size = NSNumber(value: attrVals.fileSize ?? 0)
+            let isDirectory = attrVals.isDirectory ?? false
+
+            return Document(name: fileName, url: url, size: size, created: created, modified: modified, isDirectory: isDirectory)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Tests/DirectoryBrowserTests/SearchTests/DocumentSearcherTests.swift
+++ b/Tests/DirectoryBrowserTests/SearchTests/DocumentSearcherTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import DirectoryBrowser
+import DirectoryManager
+
+@MainActor
+final class DocumentSearcherTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = URL.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot)
+        let fileURL = tempRoot.appendingPathComponent("TestFile.txt")
+        FileManager.default.createFile(atPath: fileURL.path, contents: Data())
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempRoot)
+    }
+
+    func testSearchFindsFile() {
+        let searcher = DocumentSearcher(roots: [tempRoot])
+        searcher.search(query: "testfile")
+        XCTAssertTrue(searcher.results.contains { $0.document.name == "TestFile.txt" })
+    }
+}

--- a/Tests/DirectoryBrowserTests/UtilsTests/HumanReadablePathTests.swift
+++ b/Tests/DirectoryBrowserTests/UtilsTests/HumanReadablePathTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import DirectoryBrowser
+
+final class HumanReadablePathTests: XCTestCase {
+    func testHumanReadablePath() {
+        let root = URL(fileURLWithPath: "/var/mobile/Documents", isDirectory: true)
+        let file = root.appendingPathComponent("Foo/bar.txt")
+        let path = humanReadablePath(for: file, root: root)
+        XCTAssertEqual(path, "Documents/Foo/bar.txt")
+    }
+}


### PR DESCRIPTION
## Summary
- add `DocumentSearcher` utility for recursive search across multiple roots
- generate user-friendly relative paths
- show searchable results in `DirectoryBrowser`
- test searcher logic and path formatting

## Testing
- `swift test -q` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685872e1d354832385dd68e568e3547a