### PR TITLE
Add UserDefaults browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Useful during development and debugging.
 - View, browse and delete list of all files and folders in app's temporary folder, Documents and Library folders.
 - Preview thumbnails and content.
 - Create folder, import from Photos and Files apps.
+- Preview and edit UserDefaults values.
 
 ## Installation
 

--- a/Sources/DirectoryBrowser/DirectoryBrowser.swift
+++ b/Sources/DirectoryBrowser/DirectoryBrowser.swift
@@ -28,9 +28,19 @@ public struct DirectoryBrowser: View {
         NavigationView {
             Group {
                 if searcher.results.isEmpty && searchText.isEmpty {
-                    List(urls) { url in
-                        NavigationLink(url.lastPathComponent) {
-                            FolderView(documentsStore: DocumentsStore(root: url), title: url.lastPathComponent)
+                    List {
+                        Section(header: Text("Directories")) {
+                            ForEach(urls) { url in
+                                NavigationLink(url.lastPathComponent) {
+                                    FolderView(documentsStore: DocumentsStore(root: url), title: url.lastPathComponent)
+                                }
+                            }
+                        }
+
+                        Section {
+                            NavigationLink("User Defaults") {
+                                UserDefaultsView()
+                            }
                         }
                     }
                 } else {

--- a/Sources/DirectoryBrowser/README.md
+++ b/Sources/DirectoryBrowser/README.md
@@ -1,6 +1,6 @@
 # DirectoryBrowser
 
-`DirectoryBrowser` is a SwiftUI view that presents a list of directories and allows users to navigate and manage the files inside them.
+`DirectoryBrowser` is a SwiftUI view that presents a list of directories and allows users to navigate and manage the files inside them. It can also display and edit the app's `UserDefaults` values.
 
 ## Presenting the View
 

--- a/Sources/DirectoryBrowser/Screens/UserDefaults/UserDefaultsEditView.swift
+++ b/Sources/DirectoryBrowser/Screens/UserDefaults/UserDefaultsEditView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct UserDefaultsEditView: View {
+    var entry: UserDefaultsEntry
+    var onSave: (Any) -> Void
+
+    @State private var boolValue = false
+    @State private var textValue = ""
+
+    var body: some View {
+        Form {
+            if entry.value is Bool {
+                Toggle("Value", isOn: $boolValue)
+            } else {
+                TextField("Value", text: $textValue)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            }
+            Button("Override") {
+                var newVal: Any = entry.value
+                if entry.value is Bool {
+                    newVal = boolValue
+                } else if entry.value is Int {
+                    newVal = Int(textValue) ?? 0
+                } else if entry.value is Double {
+                    newVal = Double(textValue) ?? 0
+                } else if entry.value is Float {
+                    newVal = Float(textValue) ?? 0
+                } else {
+                    newVal = textValue
+                }
+                onSave(newVal)
+            }
+        }
+        .navigationTitle(entry.key)
+        .onAppear {
+            if let boolVal = entry.value as? Bool {
+                boolValue = boolVal
+            } else {
+                textValue = String(describing: entry.value)
+            }
+        }
+    }
+}
+
+struct UserDefaultsEditView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            UserDefaultsEditView(entry: UserDefaultsEntry(key: "Some", value: true), onSave: { _ in })
+        }
+    }
+}

--- a/Sources/DirectoryBrowser/Screens/UserDefaults/UserDefaultsEntry.swift
+++ b/Sources/DirectoryBrowser/Screens/UserDefaults/UserDefaultsEntry.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct UserDefaultsEntry: Identifiable {
+    let key: String
+    var value: Any
+    var id: String { key }
+
+    var displayValue: String {
+        switch value {
+        case let bool as Bool:
+            return bool ? "true" : "false"
+        case let str as String:
+            return str
+        default:
+            return String(describing: value)
+        }
+    }
+}

--- a/Sources/DirectoryBrowser/Screens/UserDefaults/UserDefaultsView.swift
+++ b/Sources/DirectoryBrowser/Screens/UserDefaults/UserDefaultsView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct UserDefaultsView: View {
+    @State private var entries: [UserDefaultsEntry] = []
+
+    var body: some View {
+        List(entries) { entry in
+            NavigationLink(destination: UserDefaultsEditView(entry: entry, onSave: { newValue in
+                UserDefaults.standard.setValue(newValue, forKey: entry.key)
+                load()
+            })) {
+                HStack {
+                    Text(entry.key)
+                    Spacer()
+                    Text(entry.displayValue)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .navigationTitle("User Defaults")
+        .onAppear(perform: load)
+    }
+
+    private func load() {
+        let dict = UserDefaults.standard.dictionaryRepresentation()
+        entries = dict.map { UserDefaultsEntry(key: $0.key, value: $0.value) }
+            .sorted { $0.key < $1.key }
+    }
+}
+
+struct UserDefaultsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            UserDefaultsView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- list directories in a section and add a User Defaults entry
- implement UI for reading and editing UserDefaults
- document the new UserDefaults feature

## Testing
- `swift test --disable-sandbox` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6861ce02ba1883238a6dbdeb6de31006